### PR TITLE
Add test codes for states.

### DIFF
--- a/contracts/src/test/java/com/r3/developers/apples/TestUtils.java
+++ b/contracts/src/test/java/com/r3/developers/apples/TestUtils.java
@@ -1,6 +1,19 @@
 package com.r3.developers.apples;
 
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+
 public class TestUtils {
 
+    /** TODO:
+     * キーペアを作成。ダミーNodeを生成するテストフレームワークの用意がないため、KeyPairGeneratorで代替。
+     * 将来のテストフレームワークで上記機能が提供された場合は変更する。
+    */
+    public static KeyPair generateKey() throws NoSuchAlgorithmException {
 
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(4096);
+        return keyPairGenerator.generateKeyPair();
+    }
 }

--- a/contracts/src/test/java/com/r3/developers/apples/states/AppleStampTest.java
+++ b/contracts/src/test/java/com/r3/developers/apples/states/AppleStampTest.java
@@ -1,9 +1,13 @@
 package com.r3.developers.apples.states;
 
+import com.r3.developers.apples.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import java.util.ArrayList;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -58,7 +62,48 @@ class AppleStampTest {
         assertTrue(holderField.getType().isAssignableFrom(PublicKey.class));
     }
 
+    /**
+     * Task 5.
+     * TODO: Check to see if the AppleState's issue field is included in the participants.
+     */
     @Test
-    void getParticipants() {
+    void issuerIsParticipant() throws NoSuchAlgorithmException {
+
+        ArrayList<PublicKey> publicKeys = new ArrayList<>();
+
+        KeyPair issuerKeys = TestUtils.generateKey();
+        publicKeys.add(issuerKeys.getPublic());
+
+        KeyPair holderKeys = TestUtils.generateKey();
+        publicKeys.add(holderKeys.getPublic());
+
+        AppleStamp appleStamp = new AppleStamp(UUID.randomUUID(), "This is a test stamp.",
+                issuerKeys.getPublic(), holderKeys.getPublic());
+
+        /* リストに期待したオブジェクトが含まれない場合、indexOfメソッドは-1を返す. */
+        assertNotEquals(appleStamp.getParticipants().indexOf(issuerKeys.getPublic()), -1);
     }
+
+    /**
+     * Task 6.
+     * TODO: Check to see if the AppleState's holder field is included in the participants.
+     */
+    @Test
+    void holderIsParticipant() throws NoSuchAlgorithmException {
+
+        ArrayList<PublicKey> publicKeys = new ArrayList<>();
+
+        KeyPair issuerKeys = TestUtils.generateKey();
+        publicKeys.add(issuerKeys.getPublic());
+
+        KeyPair holderKeys = TestUtils.generateKey();
+        publicKeys.add(holderKeys.getPublic());
+
+        AppleStamp appleStamp = new AppleStamp(UUID.randomUUID(), "This is a test stamp.",
+                issuerKeys.getPublic(), holderKeys.getPublic());
+
+        /* リストに期待したオブジェクトが含まれない場合、indexOfメソッドは-1を返す. */
+        assertNotEquals(appleStamp.getParticipants().indexOf(holderKeys.getPublic()), -1);
+    }
+
 }

--- a/contracts/src/test/java/com/r3/developers/apples/states/BasketOfApplesTest.java
+++ b/contracts/src/test/java/com/r3/developers/apples/states/BasketOfApplesTest.java
@@ -1,9 +1,13 @@
 package com.r3.developers.apples.states;
 
+import com.r3.developers.apples.TestUtils;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import java.lang.reflect.Field;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import java.util.ArrayList;
 
 class BasketOfApplesTest {
 
@@ -55,4 +59,81 @@ class BasketOfApplesTest {
         assertTrue(weightField.getType().isAssignableFrom(Integer.class));
     }
 
+    /**
+     * Task 5.
+     * TODO: Check to see if the BasketOfApples's farm field is included in the participants.
+     */
+    @Test
+    void farmIsParticipant() throws NoSuchAlgorithmException {
+
+        ArrayList<PublicKey> publicKeys = new ArrayList<>();
+
+        KeyPair farmKeys = TestUtils.generateKey();
+        publicKeys.add(farmKeys.getPublic());
+
+        KeyPair ownerKeys = TestUtils.generateKey();
+        publicKeys.add(ownerKeys.getPublic());
+
+        BasketOfApples basketOfApples = new BasketOfApples( "Fuji, Aomori.",
+                farmKeys.getPublic(), ownerKeys.getPublic(), 100);
+
+        /* リストに期待したオブジェクトが含まれない場合、indexOfメソッドは-1を返す. */
+        assertNotEquals(basketOfApples.getParticipants().indexOf(farmKeys.getPublic()), -1);
+    }
+
+    /**
+     * Task 6.
+     * TODO: Check to see if the AppleState's owner field is included in the participants.
+     */
+    @Test
+    void ownerIsParticipant() throws NoSuchAlgorithmException {
+
+        ArrayList<PublicKey> publicKeys = new ArrayList<>();
+
+        KeyPair farmKeys = TestUtils.generateKey();
+        publicKeys.add(farmKeys.getPublic());
+
+        KeyPair ownerKeys = TestUtils.generateKey();
+        publicKeys.add(ownerKeys.getPublic());
+
+        BasketOfApples basketOfApples = new BasketOfApples( "Fuji, Aomori.",
+                farmKeys.getPublic(), ownerKeys.getPublic(), 100);
+
+        /* リストに期待したオブジェクトが含まれない場合、indexOfメソッドは-1を返す. */
+        assertNotEquals(basketOfApples.getParticipants().indexOf(ownerKeys.getPublic()), -1);
+    }
+
+    /**
+     * Task 7.
+     * TODO: Verified that the helper method to update Owner functions correctly.
+     */
+    @Test
+    void checkWithChangeOwnerHelperMethod() throws NoSuchAlgorithmException {
+
+        ArrayList<PublicKey> publicKeys = new ArrayList<>();
+
+        KeyPair farmKeys = TestUtils.generateKey();
+        publicKeys.add(farmKeys.getPublic());
+
+        KeyPair ownerKeys = TestUtils.generateKey();
+        publicKeys.add(ownerKeys.getPublic());
+
+        KeyPair newOwnerKeys = TestUtils.generateKey();
+        publicKeys.add(newOwnerKeys.getPublic());
+
+        BasketOfApples basketOfApples = new BasketOfApples( "Fuji, Aomori.",
+                farmKeys.getPublic(), ownerKeys.getPublic(), 100);
+
+        /* 鍵更新*/
+        BasketOfApples newOwnerBasketOfApples = basketOfApples.changeOwner(newOwnerKeys.getPublic());
+
+        /* Ownerの鍵が更新されていることを確認。 */
+        assertEquals(newOwnerBasketOfApples.getOwner(), newOwnerKeys.getPublic());
+
+        /* 他のフィールドが更新されていないことを確認。 */
+        assertEquals(newOwnerBasketOfApples.getDescription(), basketOfApples.getDescription());
+        assertEquals(newOwnerBasketOfApples.getFarm(), basketOfApples.getFarm());
+        assertEquals(newOwnerBasketOfApples.getWeight(), basketOfApples.getWeight());
+
+    }
 }


### PR DESCRIPTION
各々のState用のテストコードを追加。
- テストコードに使うnodeに関しては、ダミーNodeを作成するようなテストモジュールがないため独自でPublicKeyを発行しているが、今後テストモジュールが作られたら改修を検討。